### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o 2048-ai . && chmod +x 2048-ai && ./2048-ai"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/xwjdsh/2048-ai)](https://goreportcard.com/report/github.com/xwjdsh/2048-ai)
 [![](https://images.microbadger.com/badges/image/wendellsun/2048-ai.svg)](https://microbadger.com/images/wendellsun/2048-ai "Get your own image badge on microbadger.com")
 [![DUB](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/xwjdsh/2048-ai/blob/master/LICENSE)
+[![run on repl.it](http://repl.it/badge/github/xwjdsh/2048-ai)](https://repl.it/github/xwjdsh/2048-ai)
 
 AI for the 2048 game, implements by expectimax search, powered by Go.
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-2048-ai):

![image](https://i.imgur.com/zAMEDhR.png)
